### PR TITLE
Made databaseURL optional in admin init config (#635)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -80,7 +80,7 @@ interface InitConfig {
       clientEmail: string
       privateKey: string
     }
-    databaseURL: string
+    databaseURL?: string
   }
   firebaseAuthEmulatorHost?: string
   firebaseClientInitConfig: {


### PR DESCRIPTION
In reference to #634 , made the property databaseURL optional in firebaseAdminInitConfig .